### PR TITLE
feat: add transactions

### DIFF
--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -99,7 +99,7 @@ class Firestore {
   /// Data accessed with the transaction will not reflect local changes that
   /// have not been committed. For this reason, it is required that all
   /// reads are performed before any writes. Transactions must be performed
-  /// while online. Otherwise, reads will fail, and the final commit will fail.
+  /// with an internet connection. Otherwise, reads will fail, and the final commit will fail.
   ///
   /// By default transactions will retry 5 times. You can change the number of attempts
   /// with [maxAttempts]. Attempts should be at least 1.

--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -110,7 +110,7 @@ class Firestore {
   ///     final doc = await transaction.get('myCollection/documentId');
   ///     final value = doc.map['key'];
   ///     final newValue = value + 1;
-  ///     await transaction.update('myCollection/documentId', {'key': newValue});
+  ///     transaction.update('myCollection/documentId', {'key': newValue});
   ///   },
   /// );
   /// ```

--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -82,6 +82,35 @@ class Firestore {
 
   DocumentReference document(String path) => DocumentReference(_gateway, path);
 
+  /// Executes the given [TransactionHandler] and then attempts to commit the
+  /// changes applied within an atomic transaction.
+  ///
+  /// In the [TransactionHandler], a set of reads and writes can be performed
+  /// atomically using the [Transaction] object passed to the [TransactionHandler].
+  /// After the [TransactionHandler] is run, [Firestore] will attempt to apply the
+  /// changes to the server. If any of the data read has been modified outside
+  /// of this [Transaction] since being read, then the transaction will be
+  /// retried by executing the provided [TransactionHandler] again. If the transaction still
+  /// fails after 5 retries, then the transaction will fail.
+  ///
+  /// The [TransactionHandler] may be executed multiple times, it should be able
+  /// to handle multiple executions.
+  ///
+  /// Data accessed with the transaction will not reflect local changes that
+  /// have not been committed. For this reason, it is required that all
+  /// reads are performed before any writes. Transactions must be performed
+  /// while online. Otherwise, reads will fail, and the final commit will fail.
+  ///
+  /// By default transactions will retry 5 times. You can change the number of attempts
+  /// with [maxAttempts]. Attempts should be at least 1.
+  Future<T> runTransaction<T>(
+    TransactionHandler<T> handler, {
+    int maxAttempts = 5,
+  }) {
+    assert(maxAttempts >= 1, 'maxAttempts must be at least 1.');
+    return _gateway.runTransaction(handler, maxAttempts: maxAttempts);
+  }
+
   void close() {
     _gateway.close();
   }

--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -91,7 +91,7 @@ class Firestore {
   /// changes to the server. If any of the data read has been modified outside
   /// of this [Transaction] since being read, then the transaction will be
   /// retried by executing the provided [TransactionHandler] again. If the transaction still
-  /// fails after 5 retries, then the transaction will fail.
+  /// fails after the specified [maxAttempts] retries, then the transaction will fail.
   ///
   /// The [TransactionHandler] may be executed multiple times, it should be able
   /// to handle multiple executions.

--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -103,6 +103,17 @@ class Firestore {
   ///
   /// By default transactions will retry 5 times. You can change the number of attempts
   /// with [maxAttempts]. Attempts should be at least 1.
+  ///
+  /// ```dart
+  /// await firestore.runTransaction(
+  ///   (transaction) async {
+  ///     final doc = await transaction.get('myCollection/documentId');
+  ///     final value = doc.map['key'];
+  ///     final newValue = value + 1;
+  ///     await transaction.update('myCollection/documentId', {'key': newValue});
+  ///   },
+  /// );
+  /// ```
   Future<T> runTransaction<T>(
     TransactionHandler<T> handler, {
     int maxAttempts = 5,

--- a/lib/firestore/firestore_gateway.dart
+++ b/lib/firestore/firestore_gateway.dart
@@ -196,7 +196,7 @@ class FirestoreGateway {
     var commitRequest = CommitRequest(
       database: database,
       transaction: transactionId,
-      writes: transaction.writeMutations,
+      writes: transaction.mutations,
     );
     await _client.commit(commitRequest).catchError(_handleError);
 

--- a/lib/firestore/firestore_gateway.dart
+++ b/lib/firestore/firestore_gateway.dart
@@ -14,7 +14,9 @@ typedef RequestAuthenticator = Future<void>? Function(
 class FirestoreGateway {
   final RequestAuthenticator? _authenticator;
 
-  final String database;
+  late final String database;
+
+  late final String documentDatabase;
 
   final Map<String, _ListenStreamWrapper> _listenStreamCache;
 
@@ -28,9 +30,9 @@ class FirestoreGateway {
     RequestAuthenticator? authenticator,
     Emulator? emulator,
   })  : _authenticator = authenticator,
-        database =
-            'projects/$projectId/databases/${databaseId ?? '(default)'}/documents',
         _listenStreamCache = <String, _ListenStreamWrapper>{} {
+    database = 'projects/$projectId/databases/${databaseId ?? '(default)'}';
+    documentDatabase = '$database/documents';
     _setupClient(emulator: emulator);
   }
 
@@ -61,14 +63,14 @@ class FirestoreGateway {
       ..structuredQuery = query;
     final target = Target()..query = queryTarget;
     final request = ListenRequest()
-      ..database = database
+      ..database = documentDatabase
       ..addTarget = target;
 
     _listenStreamCache[path] = _ListenStreamWrapper.create(
         request,
         (requestStream) => _client.listen(requestStream,
             options: CallOptions(
-                metadata: {'google-cloud-resource-prefix': database})),
+                metadata: {'google-cloud-resource-prefix': documentDatabase})),
         onDone: () => _listenStreamCache.remove(path));
 
     return _mapCollectionStream(_listenStreamCache[path]!);
@@ -133,14 +135,14 @@ class FirestoreGateway {
     final documentsTarget = Target_DocumentsTarget()..documents.add(path);
     final target = Target()..documents = documentsTarget;
     final request = ListenRequest()
-      ..database = database
+      ..database = documentDatabase
       ..addTarget = target;
 
     _listenStreamCache[path] = _ListenStreamWrapper.create(
         request,
         (requestStream) => _client.listen(requestStream,
             options: CallOptions(
-                metadata: {'google-cloud-resource-prefix': database})),
+                metadata: {'google-cloud-resource-prefix': documentDatabase})),
         onDone: () => _listenStreamCache.remove(path));
 
     return _mapDocumentStream(_listenStreamCache[path]!.stream);

--- a/lib/firestore/firestore_gateway.dart
+++ b/lib/firestore/firestore_gateway.dart
@@ -91,10 +91,18 @@ class FirestoreGateway {
     return Document(this, response);
   }
 
-  Future<Document> getDocument(path) async {
-    var rawDocument = await _client
-        .getDocument(GetDocumentRequest()..name = path)
-        .catchError(_handleError);
+  Future<Document> getDocument(
+    String path, {
+    List<int>? transaction,
+  }) async {
+    var getDocumentRequest = GetDocumentRequest()..name = path;
+
+    if (transaction != null) {
+      getDocumentRequest.transaction = transaction;
+    }
+
+    var rawDocument =
+        await _client.getDocument(getDocumentRequest).catchError(_handleError);
     return Document(this, rawDocument);
   }
 

--- a/lib/firestore/models.dart
+++ b/lib/firestore/models.dart
@@ -1,7 +1,9 @@
 import 'dart:collection';
 
+import 'package:firedart/generated/google/firestore/v1/common.pb.dart';
 import 'package:firedart/generated/google/firestore/v1/document.pb.dart' as fs;
 import 'package:firedart/generated/google/firestore/v1/query.pb.dart';
+import 'package:firedart/generated/google/firestore/v1/write.pb.dart';
 import 'package:firedart/generated/google/protobuf/wrappers.pb.dart';
 import 'package:firedart/generated/google/type/latlng.pb.dart';
 import 'package:grpc/grpc.dart';
@@ -15,11 +17,11 @@ abstract class Reference {
 
   String get id => path.substring(path.lastIndexOf('/') + 1);
 
-  String get fullPath => '${_gateway.database}/$path';
+  String get fullPath => '${_gateway.documentDatabase}/$path';
 
   Reference(this._gateway, String path)
-      : path = _trimSlashes(path.startsWith(_gateway.database)
-            ? path.substring(_gateway.database.length + 1)
+      : path = _trimSlashes(path.startsWith(_gateway.documentDatabase)
+            ? path.substring(_gateway.documentDatabase.length + 1)
             : path);
 
   factory Reference.create(FirestoreGateway gateway, String path) {
@@ -371,5 +373,81 @@ class QueryReference extends Reference {
     compositeFilter.filters.add(queryFilter);
     _structuredQuery.where = StructuredQuery_Filter()
       ..compositeFilter = compositeFilter;
+  }
+}
+
+/// Signature of a transaction callback.
+typedef TransactionHandler<T> = Future<T> Function(Transaction transaction);
+
+class Transaction {
+  final FirestoreGateway _gateway;
+  final List<int> _transaction;
+
+  Transaction(this._gateway, this._transaction);
+
+  // TODO(jsgalarraga): this shouldn't be public
+  final List<Write> writeMutations = <Write>[];
+
+  String _fullPath(String path) => '${_gateway.documentDatabase}/$path';
+
+  Map<String, fs.Value> _encodeMap(Map<String, dynamic> map) {
+    return map.map((key, value) => MapEntry(key, TypeUtil.encode(value)));
+  }
+
+  /// Reads the document referenced by the provided [path].
+  ///
+  /// If the document does not exist, the operation throws a [GrpcError] with
+  /// [StatusCode.notFound].
+  Future<Document> get(String path) async {
+    return _gateway.getDocument(
+      _fullPath(path),
+      transaction: _transaction,
+    );
+  }
+
+  /// Deletes the document referred by the provided [path].
+  ///
+  /// If the document does not exist, the operation does nothing and returns
+  /// normally.
+  Future<void> delete(String path) async {
+    writeMutations.add(
+      Write(delete: _fullPath(path)),
+    );
+  }
+
+  /// Updates fields provided in [data] for the document referred to by [path].
+  ///
+  /// Only the fields specified in [data] will be updated. Fields that
+  /// are not specified in [data] will not be changed.
+  ///
+  /// If the document does not yet exist, it will be created.
+  Future<void> update(String path, Map<String, dynamic> data) async {
+    writeMutations.add(
+      Write(
+        updateMask: DocumentMask(fieldPaths: data.keys),
+        update: fs.Document(
+          name: _fullPath(path),
+          fields: _encodeMap(data),
+        ),
+      ),
+    );
+  }
+
+  /// Sets fields provided in [data] for the document referred to by [path].
+  ///
+  /// All fields will be overwritten with the provided [data]. This means
+  /// that all fields that are not specified in [data] will be deleted.
+  ///
+  /// If the document does not yet exist, it will be created.
+  Future<void> set(String path, Map<String, dynamic> data) async {
+    writeMutations.add(
+      Write(
+        updateMask: null,
+        update: fs.Document(
+          name: _fullPath(path),
+          fields: _encodeMap(data),
+        ),
+      ),
+    );
   }
 }

--- a/lib/firestore/models.dart
+++ b/lib/firestore/models.dart
@@ -385,8 +385,10 @@ class Transaction {
 
   Transaction(this._gateway, this._transaction);
 
-  // TODO(jsgalarraga): this shouldn't be public
-  final List<Write> writeMutations = <Write>[];
+  final List<Write> _mutations = <Write>[];
+
+  /// An immutable list of the [Write]s that have been added to this transaction.
+  UnmodifiableListView<Write> get mutations => UnmodifiableListView(_mutations);
 
   String _fullPath(String path) => '${_gateway.documentDatabase}/$path';
 
@@ -410,7 +412,7 @@ class Transaction {
   /// If the document does not exist, the operation does nothing and returns
   /// normally.
   Future<void> delete(String path) async {
-    writeMutations.add(
+    _mutations.add(
       Write(delete: _fullPath(path)),
     );
   }
@@ -422,7 +424,7 @@ class Transaction {
   ///
   /// If the document does not yet exist, it will be created.
   Future<void> update(String path, Map<String, dynamic> data) async {
-    writeMutations.add(
+    _mutations.add(
       Write(
         updateMask: DocumentMask(fieldPaths: data.keys),
         update: fs.Document(
@@ -440,7 +442,7 @@ class Transaction {
   ///
   /// If the document does not yet exist, it will be created.
   Future<void> set(String path, Map<String, dynamic> data) async {
-    writeMutations.add(
+    _mutations.add(
       Write(
         updateMask: null,
         update: fs.Document(

--- a/lib/firestore/models.dart
+++ b/lib/firestore/models.dart
@@ -411,7 +411,7 @@ class Transaction {
   ///
   /// If the document does not exist, the operation does nothing and returns
   /// normally.
-  Future<void> delete(String path) async {
+  void delete(String path) {
     _mutations.add(
       Write(delete: _fullPath(path)),
     );
@@ -423,7 +423,7 @@ class Transaction {
   /// are not specified in [data] will not be changed.
   ///
   /// If the document does not yet exist, it will be created.
-  Future<void> update(String path, Map<String, dynamic> data) async {
+  void update(String path, Map<String, dynamic> data) {
     _mutations.add(
       Write(
         updateMask: DocumentMask(fieldPaths: data.keys),
@@ -441,7 +441,7 @@ class Transaction {
   /// that all fields that are not specified in [data] will be deleted.
   ///
   /// If the document does not yet exist, it will be created.
-  Future<void> set(String path, Map<String, dynamic> data) async {
+  void set(String path, Map<String, dynamic> data) {
     _mutations.add(
       Write(
         updateMask: null,

--- a/lib/firestore/models.dart
+++ b/lib/firestore/models.dart
@@ -379,6 +379,7 @@ class QueryReference extends Reference {
 /// Signature of a transaction callback.
 typedef TransactionHandler<T> = Future<T> Function(Transaction transaction);
 
+/// Transaction class which is created from a call to [runTransaction()].
 class Transaction {
   final FirestoreGateway _gateway;
   final List<int> _transaction;

--- a/lib/firestore/models.dart
+++ b/lib/firestore/models.dart
@@ -390,12 +390,6 @@ class Transaction {
   /// An immutable list of the [Write]s that have been added to this transaction.
   UnmodifiableListView<Write> get mutations => UnmodifiableListView(_mutations);
 
-  String _fullPath(String path) => '${_gateway.documentDatabase}/$path';
-
-  Map<String, fs.Value> _encodeMap(Map<String, dynamic> map) {
-    return map.map((key, value) => MapEntry(key, TypeUtil.encode(value)));
-  }
-
   /// Reads the document referenced by the provided [path].
   ///
   /// If the document does not exist, the operation throws a [GrpcError] with
@@ -451,5 +445,11 @@ class Transaction {
         ),
       ),
     );
+  }
+
+  String _fullPath(String path) => '${_gateway.documentDatabase}/$path';
+
+  Map<String, fs.Value> _encodeMap(Map<String, dynamic> map) {
+    return map.map((key, value) => MapEntry(key, TypeUtil.encode(value)));
   }
 }


### PR DESCRIPTION
Dummy PR to make easier to see changes

---

This PR introduces Firestore [transactions](https://firebase.google.com/docs/firestore/manage-data/transactions#transactions) to the package.

## Why

Transactions are a powerful feature to have in the backend. This is an effort to have a more complete feature set for a dart backend.

It has been requested by users in #63 and #126.

## Inspiration

The work here has been inspired by:
- The [Firebase SDK for Android](https://github.com/firebase/firebase-android-sdk/tree/main/firebase-firestore/src/main/java/com/google/firebase/firestore). In particular the creation of a new [`Transaction` class](https://github.com/firebase/firebase-android-sdk/blob/main/firebase-firestore/src/main/java/com/google/firebase/firestore/core/Transaction.java) that exposes the methods that can be performed.
- The [cloud_firestore](https://github.com/firebase/flutterfire/blob/master/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart#L292) package for Flutter. In particular, the API exposed to the user and the documentation.

## Implementation notes
- The new `Transaction` class, does not extend the existing `Reference` even though it needs some of its methods because a `Transaction` does not have a predefined `path`. The `_fullPath` and `_encodeMap` methods have been adapted.
- The `mutations` in a `Transaction` have to be exposed for the `FirestoreGateway` to have access to them and run the transaction `commit`. To safely do this, it is kept as an `UnmodifiableListView` to prevent the end user from modifying it.
- When multiple transaction operations are run in parallel, some of them fail to keep the database consistent. When this happens, a `GrpcError` with `StatusCode.aborted` is thrown. In this PR, the error handling is implemented to retry the transaction up to 5 times by default (as the other firestore SDKs do).

## Examples
To ensure transactions are working and keeping the database consistent with all the write operations performed in parallel, the following test has been run: Increase a value multiple times both with and without transactions. As we can see, when running with transactions, the numbers are increased correctly 3 times, but the number is only increased by 1 when ran without transactions.

https://github.com/jsgalarraga/firedart/assets/52668514/559a8fa7-62ec-4a46-a41e-fbcb565392ce

### With transactions
```dart
void main(List<String> args) async {
  Firestore.initialize('project-id');

  await Future.wait([
    increaseValueWithTransaction(Firestore.instance),
    increaseValueWithTransaction(Firestore.instance),
    increaseValueWithTransaction(Firestore.instance),
  ]);

  firestore.close();
}

Future<void> increaseValueWithTransaction(Firestore firestore) async {
  await firestore.runTransaction(
    (transaction) async {
      final doc = await transaction.get('testing/test');
      final value = doc.map['key'];
      transaction.update('testing/test', {'key': value + 1});
    },
  );
}
```

### Without transactions
```dart
void main(List<String> args) async {
  Firestore.initialize('project-id');

  await Future.wait([
    increaseValue(Firestore.instance),
    increaseValue(Firestore.instance),
    increaseValue(Firestore.instance),
  ]);

  firestore.close();
}

Future<void> increaseValue(Firestore firestore) async {
  final doc = await firestore.document('testing/test').get();
  final value = doc.map['key'];
  await firestore.document('testing/test').set({'key': value + 1});
}
```